### PR TITLE
Generate ACM reference for `DistributionConfig.ViewerCertificate`

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2024-02-14T04:03:15Z"
-  build_hash: 947081ffebdeefcf2c61c4ca6d7e68810bdf9d08
+  build_date: "2024-02-19T19:45:25Z"
+  build_hash: 9c8a01fdcb2bcf7448cd9f9549c8b480e424e927
   go_version: go1.22.0
-  version: v0.30.0
-api_directory_checksum: 0772737bbcb79c3ab3ac8aa6b8d0e723ee28c401
+  version: v0.30.0-6-g9c8a01f-dirty
+api_directory_checksum: 86a18c0bfcc849ad234f64249fd8951ce418dd14
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.214
 generator_config_info:
-  file_checksum: b865d43d27deaab5980043ea80d2fc0c34f779fc
+  file_checksum: 4faafc515699468a833ad70b7cbc8d2260477ea1
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -193,6 +193,11 @@ resources:
       CallerReference:
         type: string
         is_read_only: true
+      DistributionConfig.ViewerCertificate.ACMCertificateARN:
+        references:
+          service_name: acm
+          resource: Certificate
+          path: Status.ACKResourceMetadata.ARN
   Function:
     tags:
       ignore: true

--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -2019,11 +2019,13 @@ type TrustedSigners struct {
 // and Using Alternate Domain Names and HTTPS (https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-https-alternate-domain-names.html)
 // in the Amazon CloudFront Developer Guide.
 type ViewerCertificate struct {
-	ACMCertificateARN            *string `json:"aCMCertificateARN,omitempty"`
-	Certificate                  *string `json:"certificate,omitempty"`
-	CertificateSource            *string `json:"certificateSource,omitempty"`
-	CloudFrontDefaultCertificate *bool   `json:"cloudFrontDefaultCertificate,omitempty"`
-	IAMCertificateID             *string `json:"iamCertificateID,omitempty"`
-	MinimumProtocolVersion       *string `json:"minimumProtocolVersion,omitempty"`
-	SSLSupportMethod             *string `json:"sslSupportMethod,omitempty"`
+	ACMCertificateARN *string `json:"acmCertificateARN,omitempty"`
+	// Reference field for ACMCertificateARN
+	ACMCertificateRef            *ackv1alpha1.AWSResourceReferenceWrapper `json:"acmCertificateRef,omitempty"`
+	Certificate                  *string                                  `json:"certificate,omitempty"`
+	CertificateSource            *string                                  `json:"certificateSource,omitempty"`
+	CloudFrontDefaultCertificate *bool                                    `json:"cloudFrontDefaultCertificate,omitempty"`
+	IAMCertificateID             *string                                  `json:"iamCertificateID,omitempty"`
+	MinimumProtocolVersion       *string                                  `json:"minimumProtocolVersion,omitempty"`
+	SSLSupportMethod             *string                                  `json:"sslSupportMethod,omitempty"`
 }

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -5331,6 +5331,11 @@ func (in *ViewerCertificate) DeepCopyInto(out *ViewerCertificate) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ACMCertificateRef != nil {
+		in, out := &in.ACMCertificateRef, &out.ACMCertificateRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Certificate != nil {
 		in, out := &in.Certificate, &out.Certificate
 		*out = new(string)

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"os"
 
+	acmapitypes "github.com/aws-controllers-k8s/acm-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
 	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
@@ -60,6 +61,7 @@ func init() {
 
 	_ = svctypes.AddToScheme(scheme)
 	_ = ackv1alpha1.AddToScheme(scheme)
+	_ = acmapitypes.AddToScheme(scheme)
 }
 
 func main() {

--- a/config/crd/bases/cloudfront.services.k8s.aws_distributions.yaml
+++ b/config/crd/bases/cloudfront.services.k8s.aws_distributions.yaml
@@ -885,8 +885,20 @@ spec:
                       and Using Alternate Domain Names and HTTPS (https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-https-alternate-domain-names.html)
                       in the Amazon CloudFront Developer Guide.
                     properties:
-                      aCMCertificateARN:
+                      acmCertificateARN:
                         type: string
+                      acmCertificateRef:
+                        description: Reference field for ACMCertificateARN
+                        properties:
+                          from:
+                            description: |-
+                              AWSResourceReference provides all the values necessary to reference another
+                              k8s resource for finding the identifier(Id/ARN/Name)
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                        type: object
                       certificate:
                         type: string
                       certificateSource:

--- a/config/rbac/cluster-role-controller.yaml
+++ b/config/rbac/cluster-role-controller.yaml
@@ -31,6 +31,20 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - acm.services.k8s.aws
+  resources:
+  - certificates
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - acm.services.k8s.aws
+  resources:
+  - certificates/status
+  verbs:
+  - get
+  - list
+- apiGroups:
   - cloudfront.services.k8s.aws
   resources:
   - cachepolicies

--- a/generator.yaml
+++ b/generator.yaml
@@ -193,6 +193,11 @@ resources:
       CallerReference:
         type: string
         is_read_only: true
+      DistributionConfig.ViewerCertificate.ACMCertificateARN:
+        references:
+          service_name: acm
+          resource: Certificate
+          path: Status.ACKResourceMetadata.ARN
   Function:
     tags:
       ignore: true

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 toolchain go1.21.5
 
 require (
+	github.com/aws-controllers-k8s/acm-controller v0.0.13
 	github.com/aws-controllers-k8s/runtime v0.30.0
 	github.com/aws/aws-sdk-go v1.49.0
 	github.com/go-logr/logr v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/aws-controllers-k8s/acm-controller v0.0.13 h1:MweVMF9lAV9PpimS6L5NWVsoFfkmAfHUgoC/Msl887w=
+github.com/aws-controllers-k8s/acm-controller v0.0.13/go.mod h1:hUc8oa8RtxUk49svAoegfscFzhgmJvRCh2FklskrEwg=
 github.com/aws-controllers-k8s/runtime v0.30.0 h1:AibYRdi/7xUA3t8BA0u8g+J+OioaTAT6R4Vq8hxLiYw=
 github.com/aws-controllers-k8s/runtime v0.30.0/go.mod h1:Pv1ozlUaO11KO2mwPN/HzhAtZ70ZDE9UP24mjsbkul0=
 github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=

--- a/helm/crds/cloudfront.services.k8s.aws_distributions.yaml
+++ b/helm/crds/cloudfront.services.k8s.aws_distributions.yaml
@@ -885,8 +885,20 @@ spec:
                       and Using Alternate Domain Names and HTTPS (https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-https-alternate-domain-names.html)
                       in the Amazon CloudFront Developer Guide.
                     properties:
-                      aCMCertificateARN:
+                      acmCertificateARN:
                         type: string
+                      acmCertificateRef:
+                        description: Reference field for ACMCertificateARN
+                        properties:
+                          from:
+                            description: |-
+                              AWSResourceReference provides all the values necessary to reference another
+                              k8s resource for finding the identifier(Id/ARN/Name)
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                        type: object
                       certificate:
                         type: string
                       certificateSource:

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -77,6 +77,20 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - acm.services.k8s.aws
+  resources:
+  - certificates
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - acm.services.k8s.aws
+  resources:
+  - certificates/status
+  verbs:
+  - get
+  - list
+- apiGroups:
   - cloudfront.services.k8s.aws
   resources:
   - cachepolicies

--- a/pkg/resource/distribution/references.go
+++ b/pkg/resource/distribution/references.go
@@ -17,12 +17,22 @@ package distribution
 
 import (
 	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	acmapitypes "github.com/aws-controllers-k8s/acm-controller/apis/v1alpha1"
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
 	svcapitypes "github.com/aws-controllers-k8s/cloudfront-controller/apis/v1alpha1"
 )
+
+// +kubebuilder:rbac:groups=acm.services.k8s.aws,resources=certificates,verbs=get;list
+// +kubebuilder:rbac:groups=acm.services.k8s.aws,resources=certificates/status,verbs=get;list
 
 // ClearResolvedReferences removes any reference values that were made
 // concrete in the spec. It returns a copy of the input AWSResource which
@@ -30,6 +40,14 @@ import (
 // values.
 func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) acktypes.AWSResource {
 	ko := rm.concreteResource(res).ko.DeepCopy()
+
+	if ko.Spec.DistributionConfig != nil {
+		if ko.Spec.DistributionConfig.ViewerCertificate != nil {
+			if ko.Spec.DistributionConfig.ViewerCertificate.ACMCertificateRef != nil {
+				ko.Spec.DistributionConfig.ViewerCertificate.ACMCertificateARN = nil
+			}
+		}
+	}
 
 	return &resource{ko}
 }
@@ -46,11 +64,111 @@ func (rm *resourceManager) ResolveReferences(
 	apiReader client.Reader,
 	res acktypes.AWSResource,
 ) (acktypes.AWSResource, bool, error) {
-	return res, false, nil
+	namespace := res.MetaObject().GetNamespace()
+	ko := rm.concreteResource(res).ko
+
+	resourceHasReferences := false
+	err := validateReferenceFields(ko)
+	if fieldHasReferences, err := rm.resolveReferenceForDistributionConfig_ViewerCertificate_ACMCertificateARN(ctx, apiReader, namespace, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	return &resource{ko}, resourceHasReferences, err
 }
 
 // validateReferenceFields validates the reference field and corresponding
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.Distribution) error {
+
+	if ko.Spec.DistributionConfig != nil {
+		if ko.Spec.DistributionConfig.ViewerCertificate != nil {
+			if ko.Spec.DistributionConfig.ViewerCertificate.ACMCertificateRef != nil && ko.Spec.DistributionConfig.ViewerCertificate.ACMCertificateARN != nil {
+				return ackerr.ResourceReferenceAndIDNotSupportedFor("DistributionConfig.ViewerCertificate.ACMCertificateARN", "DistributionConfig.ViewerCertificate.ACMCertificateRef")
+			}
+		}
+	}
+	return nil
+}
+
+// resolveReferenceForDistributionConfig_ViewerCertificate_ACMCertificateARN reads the resource referenced
+// from DistributionConfig.ViewerCertificate.ACMCertificateRef field and sets the DistributionConfig.ViewerCertificate.ACMCertificateARN
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForDistributionConfig_ViewerCertificate_ACMCertificateARN(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.Distribution,
+) (hasReferences bool, err error) {
+	if ko.Spec.DistributionConfig != nil {
+		if ko.Spec.DistributionConfig.ViewerCertificate != nil {
+			if ko.Spec.DistributionConfig.ViewerCertificate.ACMCertificateRef != nil && ko.Spec.DistributionConfig.ViewerCertificate.ACMCertificateRef.From != nil {
+				hasReferences = true
+				arr := ko.Spec.DistributionConfig.ViewerCertificate.ACMCertificateRef.From
+				if arr.Name == nil || *arr.Name == "" {
+					return hasReferences, fmt.Errorf("provided resource reference is nil or empty: DistributionConfig.ViewerCertificate.ACMCertificateRef")
+				}
+				obj := &acmapitypes.Certificate{}
+				if err := getReferencedResourceState_Certificate(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+					return hasReferences, err
+				}
+				ko.Spec.DistributionConfig.ViewerCertificate.ACMCertificateARN = (*string)(obj.Status.ACKResourceMetadata.ARN)
+			}
+		}
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_Certificate looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_Certificate(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *acmapitypes.Certificate,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceSynced, refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Certificate",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"Certificate",
+			namespace, name)
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"Certificate",
+			namespace, name)
+	}
+	if obj.Status.ACKResourceMetadata == nil || obj.Status.ACKResourceMetadata.ARN == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"Certificate",
+			namespace, name,
+			"Status.ACKResourceMetadata.ARN")
+	}
 	return nil
 }


### PR DESCRIPTION
Description of changes:
- Adding a new reference for ACM certificate ARN
- Fix `acmCertificateARN` camel case name

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
