### PR TITLE
Include `CachePolicyConfig` quantities in create and update requests

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2024-02-19T19:45:25Z"
-  build_hash: 9c8a01fdcb2bcf7448cd9f9549c8b480e424e927
+  build_date: "2024-02-27T16:58:23Z"
+  build_hash: c2165b65565ab3a094cfb474c4396f4d14c7ef1e
   go_version: go1.22.0
-  version: v0.30.0-6-g9c8a01f-dirty
+  version: v0.31.0
 api_directory_checksum: 86a18c0bfcc849ad234f64249fd8951ce418dd14
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.214
 generator_config_info:
-  file_checksum: 4faafc515699468a833ad70b7cbc8d2260477ea1
+  file_checksum: 250151346bb9c7a0bcd8cdcdb77f482f2eee0d03
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -114,6 +114,8 @@ resources:
         template_path: hooks/cache_policy/sdk_read_one_post_set_output.go.tpl
       sdk_create_post_set_output:
         template_path: hooks/cache_policy/sdk_create_post_set_output.go.tpl
+      sdk_create_post_build_request:
+        template_path: hooks/cache_policy/sdk_create_post_build_request.go.tpl
       sdk_update_post_build_request:
         template_path: hooks/cache_policy/sdk_update_post_build_request.go.tpl
       sdk_update_post_set_output:

--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -6,4 +6,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: public.ecr.aws/aws-controllers-k8s/cloudfront-controller
-  newTag: 0.0.7
+  newTag: 0.0.8

--- a/generator.yaml
+++ b/generator.yaml
@@ -114,6 +114,8 @@ resources:
         template_path: hooks/cache_policy/sdk_read_one_post_set_output.go.tpl
       sdk_create_post_set_output:
         template_path: hooks/cache_policy/sdk_create_post_set_output.go.tpl
+      sdk_create_post_build_request:
+        template_path: hooks/cache_policy/sdk_create_post_build_request.go.tpl
       sdk_update_post_build_request:
         template_path: hooks/cache_policy/sdk_update_post_build_request.go.tpl
       sdk_update_post_set_output:

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: cloudfront-chart
 description: A Helm chart for the ACK service controller for Amazon CloudFront (CloudFront)
-version: 0.0.7
-appVersion: 0.0.7
+version: 0.0.8
+appVersion: 0.0.8
 home: https://github.com/aws-controllers-k8s/cloudfront-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,5 +1,5 @@
 {{ .Chart.Name }} has been installed.
-This chart deploys "public.ecr.aws/aws-controllers-k8s/cloudfront-controller:0.0.7".
+This chart deploys "public.ecr.aws/aws-controllers-k8s/cloudfront-controller:0.0.8".
 
 Check its status by running:
   kubectl --namespace {{ .Release.Namespace }} get pods -l "app.kubernetes.io/instance={{ .Release.Name }}"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/aws-controllers-k8s/cloudfront-controller
-  tag: 0.0.7
+  tag: 0.0.8
   pullPolicy: IfNotPresent
   pullSecrets: []
 

--- a/pkg/resource/cache_policy/hooks.go
+++ b/pkg/resource/cache_policy/hooks.go
@@ -1,0 +1,47 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cache_policy
+
+import (
+	svcsdk "github.com/aws/aws-sdk-go/service/cloudfront"
+)
+
+// setQuantityFields simply goes through the input shape and sets the Quantity
+// field for all list container parent shapes to the length of the Items field.
+// This is necessary because CloudFront's API will return an
+// `InconsistentQuantities` error message if Quantity != len(Items). This is
+// why we can't have nice things, apparently.
+func setQuantityFields(cp *svcsdk.CachePolicyConfig) {
+	if cp == nil {
+		return
+	}
+	if cp.ParametersInCacheKeyAndForwardedToOrigin != nil {
+		cpp := cp.ParametersInCacheKeyAndForwardedToOrigin
+		if cpp.CookiesConfig != nil {
+			if cpp.CookiesConfig.Cookies != nil {
+				cpp.CookiesConfig.Cookies.SetQuantity(int64(len(cpp.CookiesConfig.Cookies.Items)))
+			}
+		}
+		if cpp.HeadersConfig != nil {
+			if cpp.HeadersConfig.Headers != nil {
+				cpp.HeadersConfig.Headers.SetQuantity(int64(len(cpp.HeadersConfig.Headers.Items)))
+			}
+		}
+		if cpp.QueryStringsConfig != nil {
+			if cpp.QueryStringsConfig.QueryStrings != nil {
+				cpp.QueryStringsConfig.QueryStrings.SetQuantity(int64(len(cpp.QueryStringsConfig.QueryStrings.Items)))
+			}
+		}
+	}
+}

--- a/pkg/resource/cache_policy/sdk.go
+++ b/pkg/resource/cache_policy/sdk.go
@@ -244,6 +244,8 @@ func (rm *resourceManager) sdkCreate(
 	if err != nil {
 		return nil, err
 	}
+	// ¯\\\_(ツ)_/¯
+	setQuantityFields(input.CachePolicyConfig)
 
 	var resp *svcsdk.CreateCachePolicyOutput
 	_ = resp
@@ -493,6 +495,8 @@ func (rm *resourceManager) sdkUpdate(
 	if latest.ko.Status.ETag != nil {
 		input.SetIfMatch(*latest.ko.Status.ETag)
 	}
+	// ¯\\\_(ツ)_/¯
+	setQuantityFields(input.CachePolicyConfig)
 
 	var resp *svcsdk.UpdateCachePolicyOutput
 	_ = resp

--- a/templates/hooks/cache_policy/sdk_create_post_build_request.go.tpl
+++ b/templates/hooks/cache_policy/sdk_create_post_build_request.go.tpl
@@ -1,0 +1,2 @@
+	// ¯\\\_(ツ)_/¯
+	setQuantityFields(input.CachePolicyConfig)

--- a/templates/hooks/cache_policy/sdk_update_post_build_request.go.tpl
+++ b/templates/hooks/cache_policy/sdk_update_post_build_request.go.tpl
@@ -3,3 +3,5 @@
 	if latest.ko.Status.ETag != nil {
 		input.SetIfMatch(*latest.ko.Status.ETag)
 	}
+	// ¯\\\_(ツ)_/¯
+	setQuantityFields(input.CachePolicyConfig)

--- a/test/e2e/resources/cache_policy.yaml
+++ b/test/e2e/resources/cache_policy.yaml
@@ -7,3 +7,15 @@ spec:
     name: $CACHE_POLICY_NAME
     comment: $CACHE_POLICY_COMMENT
     minTTL: $MIN_TTL
+    parametersInCacheKeyAndForwardedToOrigin:
+      cookiesConfig:
+        cookieBehavior: none
+      enableAcceptEncodingBrotli: true
+      enableAcceptEncodingGzip: true
+      headersConfig:
+        headerBehavior: whitelist
+        headers:
+          items:
+          - Authorization
+      queryStringsConfig:
+        queryStringBehavior: all


### PR DESCRIPTION
Fixes: https://github.com/aws-controllers-k8s/community/issues/2025

CF controller is missing `CachePolicyConfig` header and cookie quantity fields. This
patch adds a similar mechanism to what's used in Distribution and other resource in
this controller.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
