### PR TITLE
Add auto-publish functionality for `Function` resources

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-05-08T01:36:10Z"
-  build_hash: c55e8227b1ff5ac6a8b8e1421a2f2076fa6a77bd
-  go_version: go1.26.2
-  version: v0.58.1
-api_directory_checksum: c88b86c2a0b51674807937a8d64f2535b3cff68f
+  build_date: "2026-05-08T22:49:36Z"
+  build_hash: ece451c52fa72a9f7cfca3b086b8a4729b592ae4
+  go_version: go1.26.0
+  version: v0.58.1-4-gece451c
+api_directory_checksum: e63cb5aa18e22b395a9e01216144dba265fc5c00
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.7
 generator_config_info:
-  file_checksum: 41d749723b259dabf0ebff8a6a1352597078ff2a
+  file_checksum: fbe73ed39012050b9e5f5f77f8d1147b444f34f6
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/annotation.go
+++ b/apis/v1alpha1/annotation.go
@@ -1,0 +1,24 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package v1alpha1
+
+import "fmt"
+
+var (
+	// AutoPublishAnnotation is the annotation key for the auto-publish annotation
+	// for CloudFront functions. This annotation is used to indicate whether a
+	// function should be automatically published after a successful update or create
+	// operation.
+	AutoPublishAnnotation = fmt.Sprintf("%s/auto-publish", GroupVersion.Group)
+)

--- a/apis/v1alpha1/function.go
+++ b/apis/v1alpha1/function.go
@@ -58,6 +58,9 @@ type FunctionStatus struct {
 	// Contains configuration information and metadata about a CloudFront function.
 	// +kubebuilder:validation:Optional
 	FunctionSummary *FunctionSummary `json:"functionSummary,omitempty"`
+	// The version identifier for the LIVE stage of the CloudFront function.
+	// +kubebuilder:validation:Optional
+	LiveETag *string `json:"liveETag,omitempty"`
 	// The URL of the CloudFront function. Use the URL to manage the function with
 	// the CloudFront API.
 	// +kubebuilder:validation:Optional

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -252,9 +252,18 @@ resources:
             to: IfMatch
           - method: Delete
             to: IfMatch
+      LiveETag:
+        is_read_only: true
+        type: string
     hooks:
       sdk_read_one_post_set_output:
         template_path: hooks/function/sdk_read_one_post_set_output.go.tpl
+      sdk_create_post_set_output:
+        template_path: hooks/function/sdk_create_post_set_output.go.tpl
+      sdk_update_post_set_output:
+        template_path: hooks/function/sdk_update_post_set_output.go.tpl
+      delta_pre_compare:
+        code: customPreCompare(delta, a, b)
   OriginAccessControl:
     tags:
       ignore: true

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -3240,6 +3240,11 @@ func (in *FunctionStatus) DeepCopyInto(out *FunctionStatus) {
 		*out = new(FunctionSummary)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.LiveETag != nil {
+		in, out := &in.LiveETag, &out.LiveETag
+		*out = new(string)
+		**out = **in
+	}
 	if in.Location != nil {
 		in, out := &in.Location, &out.Location
 		*out = new(string)

--- a/config/crd/bases/cloudfront.services.k8s.aws_functions.yaml
+++ b/config/crd/bases/cloudfront.services.k8s.aws_functions.yaml
@@ -170,6 +170,10 @@ spec:
                   status:
                     type: string
                 type: object
+              liveETag:
+                description: The version identifier for the LIVE stage of the CloudFront
+                  function.
+                type: string
               location:
                 description: |-
                   The URL of the CloudFront function. Use the URL to manage the function with

--- a/documentation.yaml
+++ b/documentation.yaml
@@ -1,0 +1,6 @@
+resources:
+  Function:
+    fields:
+      LiveETag:
+        override: |
+          The version identifier for the LIVE stage of the CloudFront function.

--- a/generator.yaml
+++ b/generator.yaml
@@ -252,9 +252,18 @@ resources:
             to: IfMatch
           - method: Delete
             to: IfMatch
+      LiveETag:
+        is_read_only: true
+        type: string
     hooks:
       sdk_read_one_post_set_output:
         template_path: hooks/function/sdk_read_one_post_set_output.go.tpl
+      sdk_create_post_set_output:
+        template_path: hooks/function/sdk_create_post_set_output.go.tpl
+      sdk_update_post_set_output:
+        template_path: hooks/function/sdk_update_post_set_output.go.tpl
+      delta_pre_compare:
+        code: customPreCompare(delta, a, b)
   OriginAccessControl:
     tags:
       ignore: true

--- a/helm/crds/cloudfront.services.k8s.aws_functions.yaml
+++ b/helm/crds/cloudfront.services.k8s.aws_functions.yaml
@@ -170,6 +170,10 @@ spec:
                   status:
                     type: string
                 type: object
+              liveETag:
+                description: The version identifier for the LIVE stage of the CloudFront
+                  function.
+                type: string
               location:
                 description: |-
                   The URL of the CloudFront function. Use the URL to manage the function with

--- a/pkg/resource/function/delta.go
+++ b/pkg/resource/function/delta.go
@@ -40,6 +40,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	customPreCompare(delta, a, b)
 
 	if !bytes.Equal(a.ko.Spec.FunctionCode, b.ko.Spec.FunctionCode) {
 		delta.Add("Spec.FunctionCode", a.ko.Spec.FunctionCode, b.ko.Spec.FunctionCode)

--- a/pkg/resource/function/hooks.go
+++ b/pkg/resource/function/hooks.go
@@ -15,12 +15,36 @@ package function
 
 import (
 	"context"
+	"errors"
+	"strconv"
 
 	"github.com/aws-controllers-k8s/cloudfront-controller/apis/v1alpha1"
+	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	svcsdk "github.com/aws/aws-sdk-go-v2/service/cloudfront"
 	svcsdktypes "github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
 )
+
+func customPreCompare(delta *ackcompare.Delta, a, b *resource) {
+	if a.ko != nil && functionAutoPublishEnabled(a.ko) &&
+		b.ko != nil && needsPublish(b.ko) {
+		delta.Add("Spec.PublishFunction", nil, nil)
+	}
+}
+
+// needsPublish returns true if the DEVELOPMENT version of the function has
+// not been published to the LIVE stage. It compares the DEVELOPMENT ETag
+// (Status.ETag) against the LIVE ETag (Status.LiveETag). If LiveETag is nil,
+// the function has never been published.
+func needsPublish(f *v1alpha1.Function) bool {
+	if f.Status.ETag == nil {
+		return false
+	}
+	if f.Status.LiveETag == nil {
+		return true
+	}
+	return *f.Status.ETag != *f.Status.LiveETag
+}
 
 // setResourceAdditionalFields sets any additional fields that are not returned
 // by the Describe API operation.
@@ -29,10 +53,36 @@ func (rm *resourceManager) setResourceAdditionalFields(ctx context.Context, r *v
 	exit := rlog.Trace("rm.setResourceAdditionalFields")
 	defer exit(err)
 
-	err = rm.setFunctionCode(ctx, r)
-	if err != nil {
+	if err = rm.setFunctionCode(ctx, r); err != nil {
 		return err
 	}
+	if err = rm.setLiveETag(ctx, r); err != nil {
+		return err
+	}
+	return nil
+}
+
+// setLiveETag describes the LIVE stage of the function and stores its ETag
+// in Status.LiveETag. If the function has never been published, LiveETag
+// is set to nil.
+func (rm *resourceManager) setLiveETag(ctx context.Context, r *v1alpha1.Function) error {
+	resp, err := rm.sdkapi.DescribeFunction(
+		ctx,
+		&svcsdk.DescribeFunctionInput{
+			Name:  r.Spec.Name,
+			Stage: svcsdktypes.FunctionStageLive,
+		},
+	)
+	rm.metrics.RecordAPICall("GET", "DescribeFunction", err)
+	if err != nil {
+		var notFound *svcsdktypes.NoSuchFunctionExists
+		if errors.As(err, &notFound) {
+			r.Status.LiveETag = nil
+			return nil
+		}
+		return err
+	}
+	r.Status.LiveETag = resp.ETag
 	return nil
 }
 
@@ -56,4 +106,41 @@ func (rm *resourceManager) setFunctionCode(ctx context.Context, r *v1alpha1.Func
 	}
 	r.Spec.FunctionCode = []byte(output.FunctionCode)
 	return nil
+}
+
+// publishes a CloudFront function
+func (rm *resourceManager) publishFunction(ctx context.Context, r *v1alpha1.Function) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.publishFunction")
+	defer func() { exit(err) }()
+
+	_, err = rm.sdkapi.PublishFunction(
+		ctx,
+		&svcsdk.PublishFunctionInput{
+			Name:    r.Spec.Name,
+			IfMatch: r.Status.ETag,
+		},
+	)
+	rm.metrics.RecordAPICall("POST", "PublishFunction", err)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// functionAutoPublishEnabled returns true if the function should be
+// automatically published after a successful update or create operation.
+func functionAutoPublishEnabled(f *v1alpha1.Function) bool {
+	annotations := f.ObjectMeta.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+
+	autoPublish, ok := annotations[v1alpha1.AutoPublishAnnotation]
+	if ok {
+		return autoPublish == strconv.FormatBool(true)
+	}
+
+	// By default we do not auto-publish functions.
+	return false
 }

--- a/pkg/resource/function/sdk.go
+++ b/pkg/resource/function/sdk.go
@@ -259,6 +259,11 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	rm.setStatusDefaults(ko)
+	if functionAutoPublishEnabled(ko) {
+		msg := "function created successfully. Requeue to autopublish"
+		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, &msg, nil)
+	}
+
 	return &resource{ko}, nil
 }
 
@@ -364,6 +369,12 @@ func (rm *resourceManager) sdkUpdate(
 	}
 
 	rm.setStatusDefaults(ko)
+	if functionAutoPublishEnabled(ko) {
+		if err := rm.publishFunction(ctx, ko); err != nil {
+			return &resource{ko}, err
+		}
+	}
+
 	return &resource{ko}, nil
 }
 

--- a/templates/hooks/function/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/function/sdk_create_post_set_output.go.tpl
@@ -1,0 +1,4 @@
+	if functionAutoPublishEnabled(ko) {
+		msg := "function created successfully. Requeue to autopublish"
+		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, &msg, nil)
+	}

--- a/templates/hooks/function/sdk_update_post_set_output.go.tpl
+++ b/templates/hooks/function/sdk_update_post_set_output.go.tpl
@@ -1,0 +1,5 @@
+	if functionAutoPublishEnabled(ko) {
+		if err := rm.publishFunction(ctx, ko); err != nil {
+			return &resource{ko}, err
+		}
+	}

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -13,8 +13,8 @@
 
 import boto3
 import pytest
-
 from acktest import k8s
+
 
 def pytest_addoption(parser):
     parser.addoption("--runslow", action="store_true", default=False, help="run slow tests")
@@ -25,6 +25,9 @@ def pytest_configure(config):
     )
     config.addinivalue_line(
         "markers", "slow: mark test as slow to run"
+    )
+    config.addinivalue_line(
+        "markers", "function_overrides: mark test with function overrides"
     )
 
 def pytest_collection_modifyitems(config, items):

--- a/test/e2e/function.py
+++ b/test/e2e/function.py
@@ -83,14 +83,22 @@ def wait_until_deleted(
             break
 
 
-def get(function_name):
+def get(function_name, stage="DEVELOPMENT"):
     """Returns a dict containing the Function record from the CloudFront
     API.
     If no such Function exists, returns None.
     """
     c = boto3.client('cloudfront')
     try:
-        resp = c.describe_function(Name=function_name)
+        resp = c.describe_function(Name=function_name, Stage=stage)
         return resp['FunctionSummary']
     except Exception:
         return None
+
+
+def get_live(function_name):
+    """Returns a dict containing the LIVE stage Function record from the
+    CloudFront API.
+    If no such Function exists in the LIVE stage, returns None.
+    """
+    return get(function_name, stage="LIVE")

--- a/test/e2e/resources/function.yaml
+++ b/test/e2e/resources/function.yaml
@@ -2,6 +2,8 @@ apiVersion: cloudfront.services.k8s.aws/v1alpha1
 kind: Function
 metadata:
   name: $FUNCTION_NAME
+  annotations:
+    cloudfront.services.k8s.aws/auto-publish: "$AUTO_PUBLISH"
 spec:
   name: $FUNCTION_NAME
   functionCode: ZnVuY3Rpb24gaGFuZGxlcihldmVudCkgewogIHJldHVybiB7CiAgICBzdGF0dXNDb2RlOiAzMDIsCiAgICBzdGF0dXNEZXNjcmlwdGlvbjogJ0ZvdW5kJywKICAgIGhlYWRlcnM6IHsKICAgICAgbG9jYXRpb246IHsgdmFsdWU6ICdodHRwczovLy8nIH0KICAgIH0KICB9Cn0K

--- a/test/e2e/tests/test_function.py
+++ b/test/e2e/tests/test_function.py
@@ -13,18 +13,17 @@
 
 """Integration tests for the CloudFront Function resource"""
 
+import logging
 import time
 
 import pytest
-
+from acktest.aws import identity
 from acktest.k8s import condition
 from acktest.k8s import resource as k8s
-from acktest.aws import identity
 from acktest.resources import random_suffix_name
-from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_resource
+from e2e import CRD_GROUP, CRD_VERSION, function, load_resource, service_marker
 from e2e.bootstrap_resources import get_bootstrap_resources
 from e2e.replacement_values import REPLACEMENT_VALUES
-from e2e import function
 
 FUNCTIONS_RESOURCE_PLURAL = "functions"
 DELETE_WAIT_AFTER_SECONDS = 10
@@ -32,8 +31,8 @@ CHECK_STATUS_WAIT_SECONDS = 30
 MODIFY_WAIT_AFTER_SECONDS = 30
 
 
-@pytest.fixture(scope="module")
-def simple_function():
+@pytest.fixture
+def simple_function(request):
     function_name = random_suffix_name("my-function", 24)
 
     # resources = get_bootstrap_resources()
@@ -45,6 +44,19 @@ def simple_function():
     replacements['FUNCTION_NAME'] = function_name
     replacements['FUNCTION_RUNTIME'] = "cloudfront-js-2.0"
     replacements['DOMAIN_NAME'] = "example.com"
+
+    # Another reason why we need to stop using python and pytest for
+    # e2e tests.
+    auto_publish = "false"
+    marker = request.node.get_closest_marker("function_overrides")
+    if marker is not None:
+        data = marker.args[0]
+        if 'auto_publish' in data:
+            if data['auto_publish'] == True:
+                logging.info("Auto publish is set to true")
+                auto_publish = "true"
+    
+    replacements['AUTO_PUBLISH'] = auto_publish
 
     resource_data = load_resource(
         "function",
@@ -107,4 +119,51 @@ class TestFunction:
 
         latest = function.get(function_name)
         assert latest is not None
+        assert latest['Status'] == "UNPUBLISHED"
         assert latest['FunctionConfig']['Comment'] == "New comment"
+
+    @pytest.mark.function_overrides({
+        'auto_publish': True,
+    })
+    def test_auto_publish(self, simple_function):
+        ref, res, function_name = simple_function
+
+        time.sleep(CHECK_STATUS_WAIT_SECONDS)
+
+        # Check that function exists
+        cr = k8s.get_resource(ref)
+        assert cr is not None
+
+        condition.assert_synced(ref)
+
+        latest = function.get(function_name)
+        assert latest is not None
+        assert latest['Status'] == "UNASSOCIATED"
+
+        # Verify the LIVE stage has the initial function config
+        live = function.get_live(function_name)
+        assert live is not None
+        assert live['FunctionConfig']['Comment'] == f"function to redirect to example.com"
+
+        updates = {
+            "spec": {
+                "functionConfig": {
+                    "comment": "New comment"
+                }
+            },
+        }
+        k8s.patch_custom_resource(ref, updates)
+        time.sleep(MODIFY_WAIT_AFTER_SECONDS)
+
+        condition.assert_synced(ref)
+
+        latest = function.get(function_name)
+        assert latest is not None
+        assert latest['FunctionConfig']['Comment'] == "New comment"
+        assert latest['Status'] == "UNASSOCIATED"
+
+        # Verify the LIVE stage was updated with the new comment
+        live = function.get_live(function_name)
+        assert live is not None
+        assert live['FunctionConfig']['Comment'] == "New comment"
+


### PR DESCRIPTION
Fixes https://github.com/aws-controllers-k8s/community/issues/2041

This patch introduces the ability for CF Functions to be automatically
published after a successful create or update operation. It adds an
annotation `cloudfront.services.k8s.aws/auto-publish` to the `Function`
resource, which when set to `true`, will trigger the automatic
publishing of the Function after a create or update.

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
