### PR TITLE
Improve `Distribution` deletion and state handling

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2024-10-10T03:58:38Z"
-  build_hash: 36c2d234498c2bc4f60773ab8df632af4067f43b
-  go_version: go1.23.2
-  version: v0.39.1
+  build_date: "2024-11-27T04:12:28Z"
+  build_hash: 9715a2a715317a76ae83825294ca50cde9afd97b
+  go_version: go1.22.4
+  version: v0.39.1-4-g9715a2a
 api_directory_checksum: 94826e55e1fdba32eb642d448aa76d1c17efe248
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.214
 generator_config_info:
-  file_checksum: fb9a1b53790c28bedf9d7a686ada69f1db662a3d
+  file_checksum: ce7fa508ec809c8f5935606218664c78980d9e21
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -1,21 +1,21 @@
 ignore:
   resource_names:
-      #- CachePolicy
-      - CloudFrontOriginAccessIdentity
-      - ContinuousDeploymentPolicy
-      #- Distribution
-      - FieldLevelEncryptionConfig
-      - FieldLevelEncryptionProfile
-      # Function
-      - Invalidation
-      - KeyGroup
-      - MonitoringSubscription
-      # - OriginAccessControl
-      # - OriginRequestPolicy
-      - PublicKey
-      - RealtimeLogConfig
-      #- ResponseHeadersPolicy
-      - StreamingDistribution
+    #- CachePolicy
+    - CloudFrontOriginAccessIdentity
+    - ContinuousDeploymentPolicy
+    #- Distribution
+    - FieldLevelEncryptionConfig
+    - FieldLevelEncryptionProfile
+    # Function
+    - Invalidation
+    - KeyGroup
+    - MonitoringSubscription
+    # - OriginAccessControl
+    # - OriginRequestPolicy
+    - PublicKey
+    - RealtimeLogConfig
+    #- ResponseHeadersPolicy
+    - StreamingDistribution
   field_paths:
     # NOTE(jaypipes): This is an idempotency token and handled automatically by
     # the controller; we don't want it as a field on the resource.
@@ -192,6 +192,8 @@ resources:
         template_path: hooks/distribution/sdk_update_post_set_output.go.tpl
       sdk_delete_post_build_request:
         template_path: hooks/distribution/sdk_delete_post_build_request.go.tpl
+      sdk_delete_pre_build_request:
+        template_path: hooks/distribution/sdk_delete_pre_build_request.go.tpl
     fields:
       ETag:
         is_read_only: true
@@ -212,10 +214,10 @@ resources:
     fields:
       ETag:
         set:
-        - method: Update
-          to: IfMatch
-        - method: Delete
-          to: IfMatch
+          - method: Update
+            to: IfMatch
+          - method: Delete
+            to: IfMatch
     hooks:
       sdk_read_one_post_set_output:
         template_path: hooks/function/sdk_read_one_post_set_output.go.tpl

--- a/generator.yaml
+++ b/generator.yaml
@@ -1,21 +1,21 @@
 ignore:
   resource_names:
-      #- CachePolicy
-      - CloudFrontOriginAccessIdentity
-      - ContinuousDeploymentPolicy
-      #- Distribution
-      - FieldLevelEncryptionConfig
-      - FieldLevelEncryptionProfile
-      # Function
-      - Invalidation
-      - KeyGroup
-      - MonitoringSubscription
-      # - OriginAccessControl
-      # - OriginRequestPolicy
-      - PublicKey
-      - RealtimeLogConfig
-      #- ResponseHeadersPolicy
-      - StreamingDistribution
+    #- CachePolicy
+    - CloudFrontOriginAccessIdentity
+    - ContinuousDeploymentPolicy
+    #- Distribution
+    - FieldLevelEncryptionConfig
+    - FieldLevelEncryptionProfile
+    # Function
+    - Invalidation
+    - KeyGroup
+    - MonitoringSubscription
+    # - OriginAccessControl
+    # - OriginRequestPolicy
+    - PublicKey
+    - RealtimeLogConfig
+    #- ResponseHeadersPolicy
+    - StreamingDistribution
   field_paths:
     # NOTE(jaypipes): This is an idempotency token and handled automatically by
     # the controller; we don't want it as a field on the resource.
@@ -192,6 +192,8 @@ resources:
         template_path: hooks/distribution/sdk_update_post_set_output.go.tpl
       sdk_delete_post_build_request:
         template_path: hooks/distribution/sdk_delete_post_build_request.go.tpl
+      sdk_delete_pre_build_request:
+        template_path: hooks/distribution/sdk_delete_pre_build_request.go.tpl
     fields:
       ETag:
         is_read_only: true
@@ -212,10 +214,10 @@ resources:
     fields:
       ETag:
         set:
-        - method: Update
-          to: IfMatch
-        - method: Delete
-          to: IfMatch
+          - method: Update
+            to: IfMatch
+          - method: Delete
+            to: IfMatch
     hooks:
       sdk_read_one_post_set_output:
         template_path: hooks/function/sdk_read_one_post_set_output.go.tpl

--- a/helm/templates/caches-role-binding.yaml
+++ b/helm/templates/caches-role-binding.yaml
@@ -8,7 +8,7 @@ roleRef:
   name: ack-namespaces-cache-cloudfront-controller
 subjects:
 - kind: ServiceAccount
-  name: ack-cloudfront-controller
+  name: {{ include "ack-cloudfront-controller.service-account.name" . }}
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -22,5 +22,5 @@ roleRef:
   name: ack-configmaps-cache-cloudfront-controller
 subjects:
 - kind: ServiceAccount
-  name: ack-cloudfront-controller
+  name: {{ include "ack-cloudfront-controller.service-account.name" . }}
   namespace: {{ .Release.Namespace }}

--- a/pkg/resource/cache_policy/descriptor.go
+++ b/pkg/resource/cache_policy/descriptor.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	finalizerString = "finalizers.cloudfront.services.k8s.aws/CachePolicy"
+	FinalizerString = "finalizers.cloudfront.services.k8s.aws/CachePolicy"
 )
 
 var (
@@ -88,8 +88,8 @@ func (d *resourceDescriptor) IsManaged(
 	// https://github.com/kubernetes-sigs/controller-runtime/issues/994 is
 	// fixed. This should be able to be:
 	//
-	// return k8sctrlutil.ContainsFinalizer(obj, finalizerString)
-	return containsFinalizer(obj, finalizerString)
+	// return k8sctrlutil.ContainsFinalizer(obj, FinalizerString)
+	return containsFinalizer(obj, FinalizerString)
 }
 
 // Remove once https://github.com/kubernetes-sigs/controller-runtime/issues/994
@@ -118,7 +118,7 @@ func (d *resourceDescriptor) MarkManaged(
 		// Should not happen. If it does, there is a bug in the code
 		panic("nil RuntimeMetaObject in AWSResource")
 	}
-	k8sctrlutil.AddFinalizer(obj, finalizerString)
+	k8sctrlutil.AddFinalizer(obj, FinalizerString)
 }
 
 // MarkUnmanaged removes the supplied resource from management by ACK.  What
@@ -133,7 +133,7 @@ func (d *resourceDescriptor) MarkUnmanaged(
 		// Should not happen. If it does, there is a bug in the code
 		panic("nil RuntimeMetaObject in AWSResource")
 	}
-	k8sctrlutil.RemoveFinalizer(obj, finalizerString)
+	k8sctrlutil.RemoveFinalizer(obj, FinalizerString)
 }
 
 // MarkAdopted places descriptors on the custom resource that indicate the

--- a/pkg/resource/distribution/descriptor.go
+++ b/pkg/resource/distribution/descriptor.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	finalizerString = "finalizers.cloudfront.services.k8s.aws/Distribution"
+	FinalizerString = "finalizers.cloudfront.services.k8s.aws/Distribution"
 )
 
 var (
@@ -88,8 +88,8 @@ func (d *resourceDescriptor) IsManaged(
 	// https://github.com/kubernetes-sigs/controller-runtime/issues/994 is
 	// fixed. This should be able to be:
 	//
-	// return k8sctrlutil.ContainsFinalizer(obj, finalizerString)
-	return containsFinalizer(obj, finalizerString)
+	// return k8sctrlutil.ContainsFinalizer(obj, FinalizerString)
+	return containsFinalizer(obj, FinalizerString)
 }
 
 // Remove once https://github.com/kubernetes-sigs/controller-runtime/issues/994
@@ -118,7 +118,7 @@ func (d *resourceDescriptor) MarkManaged(
 		// Should not happen. If it does, there is a bug in the code
 		panic("nil RuntimeMetaObject in AWSResource")
 	}
-	k8sctrlutil.AddFinalizer(obj, finalizerString)
+	k8sctrlutil.AddFinalizer(obj, FinalizerString)
 }
 
 // MarkUnmanaged removes the supplied resource from management by ACK.  What
@@ -133,7 +133,7 @@ func (d *resourceDescriptor) MarkUnmanaged(
 		// Should not happen. If it does, there is a bug in the code
 		panic("nil RuntimeMetaObject in AWSResource")
 	}
-	k8sctrlutil.RemoveFinalizer(obj, finalizerString)
+	k8sctrlutil.RemoveFinalizer(obj, FinalizerString)
 }
 
 // MarkAdopted places descriptors on the custom resource that indicate the

--- a/pkg/resource/function/descriptor.go
+++ b/pkg/resource/function/descriptor.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	finalizerString = "finalizers.cloudfront.services.k8s.aws/Function"
+	FinalizerString = "finalizers.cloudfront.services.k8s.aws/Function"
 )
 
 var (
@@ -88,8 +88,8 @@ func (d *resourceDescriptor) IsManaged(
 	// https://github.com/kubernetes-sigs/controller-runtime/issues/994 is
 	// fixed. This should be able to be:
 	//
-	// return k8sctrlutil.ContainsFinalizer(obj, finalizerString)
-	return containsFinalizer(obj, finalizerString)
+	// return k8sctrlutil.ContainsFinalizer(obj, FinalizerString)
+	return containsFinalizer(obj, FinalizerString)
 }
 
 // Remove once https://github.com/kubernetes-sigs/controller-runtime/issues/994
@@ -118,7 +118,7 @@ func (d *resourceDescriptor) MarkManaged(
 		// Should not happen. If it does, there is a bug in the code
 		panic("nil RuntimeMetaObject in AWSResource")
 	}
-	k8sctrlutil.AddFinalizer(obj, finalizerString)
+	k8sctrlutil.AddFinalizer(obj, FinalizerString)
 }
 
 // MarkUnmanaged removes the supplied resource from management by ACK.  What
@@ -133,7 +133,7 @@ func (d *resourceDescriptor) MarkUnmanaged(
 		// Should not happen. If it does, there is a bug in the code
 		panic("nil RuntimeMetaObject in AWSResource")
 	}
-	k8sctrlutil.RemoveFinalizer(obj, finalizerString)
+	k8sctrlutil.RemoveFinalizer(obj, FinalizerString)
 }
 
 // MarkAdopted places descriptors on the custom resource that indicate the

--- a/pkg/resource/origin_access_control/descriptor.go
+++ b/pkg/resource/origin_access_control/descriptor.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	finalizerString = "finalizers.cloudfront.services.k8s.aws/OriginAccessControl"
+	FinalizerString = "finalizers.cloudfront.services.k8s.aws/OriginAccessControl"
 )
 
 var (
@@ -88,8 +88,8 @@ func (d *resourceDescriptor) IsManaged(
 	// https://github.com/kubernetes-sigs/controller-runtime/issues/994 is
 	// fixed. This should be able to be:
 	//
-	// return k8sctrlutil.ContainsFinalizer(obj, finalizerString)
-	return containsFinalizer(obj, finalizerString)
+	// return k8sctrlutil.ContainsFinalizer(obj, FinalizerString)
+	return containsFinalizer(obj, FinalizerString)
 }
 
 // Remove once https://github.com/kubernetes-sigs/controller-runtime/issues/994
@@ -118,7 +118,7 @@ func (d *resourceDescriptor) MarkManaged(
 		// Should not happen. If it does, there is a bug in the code
 		panic("nil RuntimeMetaObject in AWSResource")
 	}
-	k8sctrlutil.AddFinalizer(obj, finalizerString)
+	k8sctrlutil.AddFinalizer(obj, FinalizerString)
 }
 
 // MarkUnmanaged removes the supplied resource from management by ACK.  What
@@ -133,7 +133,7 @@ func (d *resourceDescriptor) MarkUnmanaged(
 		// Should not happen. If it does, there is a bug in the code
 		panic("nil RuntimeMetaObject in AWSResource")
 	}
-	k8sctrlutil.RemoveFinalizer(obj, finalizerString)
+	k8sctrlutil.RemoveFinalizer(obj, FinalizerString)
 }
 
 // MarkAdopted places descriptors on the custom resource that indicate the

--- a/pkg/resource/origin_request_policy/descriptor.go
+++ b/pkg/resource/origin_request_policy/descriptor.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	finalizerString = "finalizers.cloudfront.services.k8s.aws/OriginRequestPolicy"
+	FinalizerString = "finalizers.cloudfront.services.k8s.aws/OriginRequestPolicy"
 )
 
 var (
@@ -88,8 +88,8 @@ func (d *resourceDescriptor) IsManaged(
 	// https://github.com/kubernetes-sigs/controller-runtime/issues/994 is
 	// fixed. This should be able to be:
 	//
-	// return k8sctrlutil.ContainsFinalizer(obj, finalizerString)
-	return containsFinalizer(obj, finalizerString)
+	// return k8sctrlutil.ContainsFinalizer(obj, FinalizerString)
+	return containsFinalizer(obj, FinalizerString)
 }
 
 // Remove once https://github.com/kubernetes-sigs/controller-runtime/issues/994
@@ -118,7 +118,7 @@ func (d *resourceDescriptor) MarkManaged(
 		// Should not happen. If it does, there is a bug in the code
 		panic("nil RuntimeMetaObject in AWSResource")
 	}
-	k8sctrlutil.AddFinalizer(obj, finalizerString)
+	k8sctrlutil.AddFinalizer(obj, FinalizerString)
 }
 
 // MarkUnmanaged removes the supplied resource from management by ACK.  What
@@ -133,7 +133,7 @@ func (d *resourceDescriptor) MarkUnmanaged(
 		// Should not happen. If it does, there is a bug in the code
 		panic("nil RuntimeMetaObject in AWSResource")
 	}
-	k8sctrlutil.RemoveFinalizer(obj, finalizerString)
+	k8sctrlutil.RemoveFinalizer(obj, FinalizerString)
 }
 
 // MarkAdopted places descriptors on the custom resource that indicate the

--- a/pkg/resource/response_headers_policy/descriptor.go
+++ b/pkg/resource/response_headers_policy/descriptor.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	finalizerString = "finalizers.cloudfront.services.k8s.aws/ResponseHeadersPolicy"
+	FinalizerString = "finalizers.cloudfront.services.k8s.aws/ResponseHeadersPolicy"
 )
 
 var (
@@ -88,8 +88,8 @@ func (d *resourceDescriptor) IsManaged(
 	// https://github.com/kubernetes-sigs/controller-runtime/issues/994 is
 	// fixed. This should be able to be:
 	//
-	// return k8sctrlutil.ContainsFinalizer(obj, finalizerString)
-	return containsFinalizer(obj, finalizerString)
+	// return k8sctrlutil.ContainsFinalizer(obj, FinalizerString)
+	return containsFinalizer(obj, FinalizerString)
 }
 
 // Remove once https://github.com/kubernetes-sigs/controller-runtime/issues/994
@@ -118,7 +118,7 @@ func (d *resourceDescriptor) MarkManaged(
 		// Should not happen. If it does, there is a bug in the code
 		panic("nil RuntimeMetaObject in AWSResource")
 	}
-	k8sctrlutil.AddFinalizer(obj, finalizerString)
+	k8sctrlutil.AddFinalizer(obj, FinalizerString)
 }
 
 // MarkUnmanaged removes the supplied resource from management by ACK.  What
@@ -133,7 +133,7 @@ func (d *resourceDescriptor) MarkUnmanaged(
 		// Should not happen. If it does, there is a bug in the code
 		panic("nil RuntimeMetaObject in AWSResource")
 	}
-	k8sctrlutil.RemoveFinalizer(obj, finalizerString)
+	k8sctrlutil.RemoveFinalizer(obj, FinalizerString)
 }
 
 // MarkAdopted places descriptors on the custom resource that indicate the

--- a/templates/hooks/distribution/sdk_delete_pre_build_request.go.tpl
+++ b/templates/hooks/distribution/sdk_delete_pre_build_request.go.tpl
@@ -1,0 +1,12 @@
+	if r.ko.Spec.DistributionConfig.Enabled != nil && *r.ko.Spec.DistributionConfig.Enabled {
+		resourceCopy := r.ko.DeepCopy()
+		// If the distribution is enabled make sure to disable it before making a delete API call
+		resourceCopy.Spec.DistributionConfig.Enabled = aws.Bool(false)
+		_, err := rm.sdkUpdate(ctx, &resource{resourceCopy}, r, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		// Now keep requeing until the distribution is disabled.
+		return nil, requeueWaitInProgress
+	}

--- a/templates/hooks/distribution/sdk_read_one_post_set_output.go.tpl
+++ b/templates/hooks/distribution/sdk_read_one_post_set_output.go.tpl
@@ -10,3 +10,8 @@
 	if resp.Distribution != nil &&  resp.Distribution.DistributionConfig != nil {
 		ko.Status.CallerReference = resp.Distribution.DistributionConfig.CallerReference
 	}
+
+	// Requeue if the distribution is in progress
+	if distributionInProgress(&resource{ko}) {
+		return &resource{ko}, requeueWaitInProgress
+	}

--- a/test/e2e/tests/test_distribution.py
+++ b/test/e2e/tests/test_distribution.py
@@ -27,9 +27,9 @@ from e2e.replacement_values import REPLACEMENT_VALUES
 from e2e import distribution
 
 DISTRIBUTION_RESOURCE_PLURAL = "distributions"
-DELETE_WAIT_AFTER_SECONDS = 10
-CHECK_STATUS_WAIT_SECONDS = 300
-MODIFY_WAIT_AFTER_SECONDS = 300
+DELETE_WAIT_AFTER_SECONDS = 600
+CHECK_STATUS_WAIT_SECONDS = 600
+MODIFY_WAIT_AFTER_SECONDS = 600
 
 
 @pytest.fixture(scope="module")
@@ -77,7 +77,7 @@ def simple_distribution():
     )
     assert deleted
 
-    distribution.wait_until_deleted(distribution_id)
+    distribution.wait_until_deleted(distribution_id, 1200, 15)
 
 
 @service_marker
@@ -127,3 +127,26 @@ class TestDistribution:
         assert 'DistributionConfig' in latest
         assert 'Enabled' in latest['DistributionConfig']
         assert bool(latest['DistributionConfig']['Enabled']) == False
+
+    def test_disable_pre_delete(self, simple_distribution):
+        ref, res, distribution_id = simple_distribution
+
+        time.sleep(CHECK_STATUS_WAIT_SECONDS)
+
+        # Before we update the Distribution CR below, let's check to see that
+        # the MinTTL field in the CR is still what we set in the original
+        # Create call.
+        cr = k8s.get_resource(ref)
+        assert cr is not None
+        assert 'spec' in cr
+        assert 'distributionConfig' in cr['spec']
+        assert 'enabled' in cr['spec']['distributionConfig']
+        assert bool(cr['spec']['distributionConfig']['enabled']) == True
+
+        condition.assert_synced(ref)
+
+        latest = distribution.get(distribution_id)
+        assert latest is not None
+        assert 'DistributionConfig' in latest
+        assert 'Enabled' in latest['DistributionConfig']
+        assert bool(latest['DistributionConfig']['Enabled']) == True


### PR DESCRIPTION
Enhance `Distribution` lifecycle management, focusing on deletion
process and state handling:

1. Implement automatic disabling of `Distributions` before deletion
2. Add requeuing mechanism for `Distributions` in 'InProgress' state
3. Update e2e tests to test disable-pre-delete scenarios and account
   for longer Distribution deletion times

These changes prevent API errors during deletion, avoid premature operations
on in-progress Distributions, and improve overall resource management
reliability.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
