### PR TITLE
Improve Distribution deletion and state handling

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2025-02-24T19:46:50Z"
+  build_date: "2025-02-25T01:04:51Z"
   build_hash: a326346bd3a6973254d247c9ab2dc76790c36241
   go_version: go1.24.0
   version: v0.43.2
@@ -7,7 +7,7 @@ api_directory_checksum: 685221abf3c89714453b284d15e9612dc2e94c90
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: 83edb89e384f2d177ab7b2d037c957e6668f1930
+  file_checksum: b97e7f96ef7e68ab84c7c5a202dda57807e6ec29
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -203,6 +203,8 @@ resources:
         template_path: hooks/distribution/sdk_update_post_set_output.go.tpl
       sdk_delete_post_build_request:
         template_path: hooks/distribution/sdk_delete_post_build_request.go.tpl
+      sdk_delete_pre_build_request:
+        template_path: hooks/distribution/sdk_delete_pre_build_request.go.tpl
     fields:
       Tags:
         from:

--- a/generator.yaml
+++ b/generator.yaml
@@ -203,6 +203,8 @@ resources:
         template_path: hooks/distribution/sdk_update_post_set_output.go.tpl
       sdk_delete_post_build_request:
         template_path: hooks/distribution/sdk_delete_post_build_request.go.tpl
+      sdk_delete_pre_build_request:
+        template_path: hooks/distribution/sdk_delete_pre_build_request.go.tpl
     fields:
       Tags:
         from:

--- a/pkg/resource/distribution/sdk.go
+++ b/pkg/resource/distribution/sdk.go
@@ -2998,6 +2998,22 @@ func (rm *resourceManager) sdkDelete(
 	defer func() {
 		exit(err)
 	}()
+	if !distributionDeployed(r) {
+		msg := "Distribution is in '" + *r.ko.Status.Status + "' status"
+		ackcondition.SetSynced(r, corev1.ConditionFalse, &msg, nil)
+		return r, requeueWaitUntilCanModify(r)
+	}
+	if r.ko.Spec.DistributionConfig.Enabled != nil && *r.ko.Spec.DistributionConfig.Enabled {
+		r.ko.Spec.DistributionConfig.Enabled = aws.Bool(false)
+		_, err = rm.sdkUpdate(ctx, r, r, &ackcompare.Delta{
+			Differences: []*ackcompare.Difference{&ackcompare.Difference{Path: ackcompare.Path{}, A: nil, B: nil}},
+		})
+		return r, ackrequeue.NeededAfter(
+			fmt.Errorf("waiting for distribution to be disabled before deletion"),
+			ackrequeue.DefaultRequeueAfterDuration,
+		)
+	}
+
 	input, err := rm.newDeleteRequestPayload(r)
 	if err != nil {
 		return nil, err

--- a/templates/hooks/distribution/sdk_delete_pre_build_request.go.tpl
+++ b/templates/hooks/distribution/sdk_delete_pre_build_request.go.tpl
@@ -1,0 +1,15 @@
+	if !distributionDeployed(r) {
+		msg := "Distribution is in '" + *r.ko.Status.Status + "' status"
+		ackcondition.SetSynced(r, corev1.ConditionFalse, &msg, nil)
+		return r, requeueWaitUntilCanModify(r)
+	}
+	if r.ko.Spec.DistributionConfig.Enabled != nil && *r.ko.Spec.DistributionConfig.Enabled {
+		r.ko.Spec.DistributionConfig.Enabled = aws.Bool(false)
+		_, err = rm.sdkUpdate(ctx, r, r, &ackcompare.Delta{
+			Differences: []*ackcompare.Difference{&ackcompare.Difference{Path: ackcompare.Path{}, A: nil, B: nil}, },
+		})
+		return r, ackrequeue.NeededAfter(
+			fmt.Errorf("waiting for distribution to be disabled before deletion"),
+			ackrequeue.DefaultRequeueAfterDuration,
+		)
+	}


### PR DESCRIPTION
Description of changes:
Enhance `Distribution` lifecycle management, focusing on deletion
process and state handling:

1. Implement automatic disabling of `Distributions` before deletion
2. Add requeuing mechanism for `Distributions` in 'InProgress' state
3. Update e2e tests to test disable-pre-delete scenarios and account
   for longer Distribution deletion times

These changes prevent API errors during deletion, avoid premature operations
on in-progress Distributions, and improve overall resource management
reliability.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
