### PR TITLE
ISSUE-2462 fix customOriginConfig:httpSPort incorrect capitalization

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2025-05-24T00:28:10Z"
+  build_date: "2025-05-30T23:11:56Z"
   build_hash: 66a58d259146834e61b211a9a01609beaa58ef77
   go_version: go1.24.2
   version: v0.47.1
-api_directory_checksum: 82a25603d2f365726507d448bd9ba70f9e190fd1
+api_directory_checksum: e4ec97e6b908a471c92cdcbafe13758d14df4cba
 api_version: v1alpha1
 aws_sdk_go_version: v1.36.3
 generator_config_info:
-  file_checksum: db6aea62160cc6f95249e601b5aa3b40fa06a5fd
+  file_checksum: f6a2252c4caf038c31b456a0ea2c77a73a2c754a
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -236,7 +236,7 @@ resources:
           resource: Certificate
           path: Status.ACKResourceMetadata.ARN
       DistributionConfig.Origins.Items.CustomOriginConfig.HTTPSPort:
-        go_tag: json:"httpSPort,omitempty"
+        go_tag: json:"httpsPort,omitempty"
   Function:
     tags:
       ignore: true

--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -503,7 +503,7 @@ type CustomHeaders struct {
 // is a custom origin.
 type CustomOriginConfig struct {
 	HTTPPort               *int64  `json:"httpPort,omitempty"`
-	HTTPSPort              *int64  `json:"httpSPort,omitempty"`
+	HTTPSPort              *int64  `json:"httpsPort,omitempty"`
 	OriginKeepaliveTimeout *int64  `json:"originKeepaliveTimeout,omitempty"`
 	OriginProtocolPolicy   *string `json:"originProtocolPolicy,omitempty"`
 	OriginReadTimeout      *int64  `json:"originReadTimeout,omitempty"`

--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -6,4 +6,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: public.ecr.aws/aws-controllers-k8s/cloudfront-controller
-  newTag: 1.1.2
+  newTag: 1.4.0

--- a/config/crd/bases/cloudfront.services.k8s.aws_distributions.yaml
+++ b/config/crd/bases/cloudfront.services.k8s.aws_distributions.yaml
@@ -720,7 +720,7 @@ spec:
                                 httpPort:
                                   format: int64
                                   type: integer
-                                httpSPort:
+                                httpsPort:
                                   format: int64
                                   type: integer
                                 originKeepaliveTimeout:

--- a/generator.yaml
+++ b/generator.yaml
@@ -236,7 +236,7 @@ resources:
           resource: Certificate
           path: Status.ACKResourceMetadata.ARN
       DistributionConfig.Origins.Items.CustomOriginConfig.HTTPSPort:
-        go_tag: json:"httpSPort,omitempty"
+        go_tag: json:"httpsPort,omitempty"
   Function:
     tags:
       ignore: true

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: cloudfront-chart
 description: A Helm chart for the ACK service controller for Amazon CloudFront (CloudFront)
-version: 1.1.2
-appVersion: 1.1.2
+version: 1.4.0
+appVersion: 1.4.0
 home: https://github.com/aws-controllers-k8s/cloudfront-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/crds/cloudfront.services.k8s.aws_distributions.yaml
+++ b/helm/crds/cloudfront.services.k8s.aws_distributions.yaml
@@ -720,7 +720,7 @@ spec:
                                 httpPort:
                                   format: int64
                                   type: integer
-                                httpSPort:
+                                httpsPort:
                                   format: int64
                                   type: integer
                                 originKeepaliveTimeout:

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,5 +1,5 @@
 {{ .Chart.Name }} has been installed.
-This chart deploys "public.ecr.aws/aws-controllers-k8s/cloudfront-controller:1.1.2".
+This chart deploys "public.ecr.aws/aws-controllers-k8s/cloudfront-controller:1.4.0".
 
 Check its status by running:
   kubectl --namespace {{ .Release.Namespace }} get pods -l "app.kubernetes.io/instance={{ .Release.Name }}"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/aws-controllers-k8s/cloudfront-controller
-  tag: 1.1.2
+  tag: 1.4.0
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
Issue #[2462](https://github.com/aws-controllers-k8s/community/issues/2462)

Description of changes:
renames httpSPort to httpsPort. It doesn't do a conversion yet, checking whether we need version of the API

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
