### PR TITLE
tests: Ready condition rename for cloudfront-controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,3 +89,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/aws-controllers-k8s/runtime => github.com/gustavodiaz7722/ack-runtime v0.54.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/aws-controllers-k8s/acm-controller v0.0.13 h1:MweVMF9lAV9PpimS6L5NWVsoFfkmAfHUgoC/Msl887w=
 github.com/aws-controllers-k8s/acm-controller v0.0.13/go.mod h1:hUc8oa8RtxUk49svAoegfscFzhgmJvRCh2FklskrEwg=
-github.com/aws-controllers-k8s/runtime v0.52.0 h1:Q5UIAn6SSBr60t/DiU/zr6NLBlUuK2AG3yy2ma/9gDU=
-github.com/aws-controllers-k8s/runtime v0.52.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=
 github.com/aws/aws-sdk-go v1.49.0/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.36.3 h1:mJoei2CxPutQVxaATCzDUjcZEjVRdpsiiXi2o38yqWM=
@@ -86,6 +84,8 @@ github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgY
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gustavodiaz7722/ack-runtime v0.54.0 h1:Mxf2oUm5Skgf0sLik5otKE5+I2+0ziC1aRWZJOwRiWQ=
+github.com/gustavodiaz7722/ack-runtime v0.54.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/itchyny/gojq v0.12.6 h1:VjaFn59Em2wTxDNGcrRkDK9ZHMNa8IksOgL13sLL4d0=
 github.com/itchyny/gojq v0.12.6/go.mod h1:ZHrkfu7A+RbZLy5J1/JKpS4poEqrzItSTGDItqsfP0A=
 github.com/itchyny/timefmt-go v0.1.3 h1:7M3LGVDsqcd0VZH2U+x393obrzZisp7C0uEe921iRkU=

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,1 +1,1 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@3b46e7e628b179df5f8466ad364b43cd2e89c015
+acktest @ git+https://github.com/gustavodiaz7722/ack-test-infra.git@77f6bc5602557fe48e0dd157fefbd97a6aa3e54b

--- a/test/e2e/tests/test_cache_policy.py
+++ b/test/e2e/tests/test_cache_policy.py
@@ -90,7 +90,7 @@ class TestCachePolicy:
         assert 'minTTL' in cr['spec']['cachePolicyConfig']
         assert cr['spec']['cachePolicyConfig']['minTTL'] == MIN_TTL
 
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         latest = cache_policy.get(cache_policy_id)
         assert latest is not None

--- a/test/e2e/tests/test_distribution.py
+++ b/test/e2e/tests/test_distribution.py
@@ -100,7 +100,7 @@ class TestDistribution:
 
         assert k8s.wait_on_condition(
             ref,
-            "ACK.ResourceSynced",
+            "Ready",
             "True",
             wait_periods=CHECK_STATUS_WAIT_SECONDS // 10,
         )
@@ -185,7 +185,7 @@ class TestDistribution:
         ref, res, distribution_id = simple_distribution
         assert k8s.wait_on_condition(
             ref,
-            "ACK.ResourceSynced",
+            "Ready",
             "True",
             wait_periods=CHECK_STATUS_WAIT_SECONDS,
         )

--- a/test/e2e/tests/test_function.py
+++ b/test/e2e/tests/test_function.py
@@ -88,7 +88,7 @@ class TestFunction:
         cr = k8s.get_resource(ref)
         assert cr is not None
 
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         latest = function.get(function_name)
         assert latest is not None

--- a/test/e2e/tests/test_origin_access_control.py
+++ b/test/e2e/tests/test_origin_access_control.py
@@ -93,7 +93,7 @@ class TestOriginAccessControl:
             == "a simple origin_access_control"
         )
 
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         latest = origin_access_control.get(origin_access_control_id)
         assert latest is not None

--- a/test/e2e/tests/test_origin_request_policy.py
+++ b/test/e2e/tests/test_origin_request_policy.py
@@ -86,7 +86,7 @@ class TestOriginRequestPolicy:
         assert 'comment' in cr['spec']['originRequestPolicyConfig']
         assert cr['spec']['originRequestPolicyConfig']['comment'] == 'a simple origin_request_policy'
 
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         latest = origin_request_policy.get(origin_request_policy_id)
         assert latest is not None

--- a/test/e2e/tests/test_response_headers_policy.py
+++ b/test/e2e/tests/test_response_headers_policy.py
@@ -86,7 +86,7 @@ class TestResponseHeadersPolicy:
         assert 'comment' in cr['spec']['responseHeadersPolicyConfig']
         assert cr['spec']['responseHeadersPolicyConfig']['comment'] == 'a simple response_headers_policy'
 
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         latest = response_headers_policy.get(response_headers_policy_id)
         assert latest is not None

--- a/test/e2e/tests/test_vpc_origin.py
+++ b/test/e2e/tests/test_vpc_origin.py
@@ -103,7 +103,7 @@ class TestVpcOrigin:
 
         assert k8s.wait_on_condition(
             ref,
-            "ACK.ResourceSynced",
+            "Ready",
             "True",
             wait_periods=CHECK_STATUS_WAIT_PERIODS,
             period_length=CHECK_STATUS_WAIT_SECONDS


### PR DESCRIPTION
This PR updates test files to the Ready condition:

- Replace `ACK.ResourceSynced` → `Ready`
- Replace `assert_synced` → `assert_ready`
- Replace `assert_not_synced` → `assert_not_ready`

Generated by helper script.